### PR TITLE
fix(writer): hacker.nvim writes unwanted characters

### DIFF
--- a/lua/hacker/writer.lua
+++ b/lua/hacker/writer.lua
@@ -2,7 +2,8 @@ local M = {}
 
 -- current index of the words
 local index = 1
-local total_newline = 1;
+local total_newline = 1
+local current_line = {}
 
 local is_type_enter = function()
   local total_lines = vim.api.nvim_buf_line_count(0)
@@ -40,17 +41,18 @@ local append_word = function(bufnr, word)
 
   if word == "\n" then
     total_newline = total_newline + 1
-    -- remove the newest char inputve the newest char input
-    vim.api.nvim_buf_set_text(bufnr, pos.s_row, pos.s_col, pos.e_row, pos.e_col, { "" })
+    vim.api.nvim_buf_set_lines(bufnr, pos.s_row, pos.s_row + 1, false, { table.concat(current_line, "") })
 
     vim.api.nvim_buf_set_lines(bufnr, pos.s_row + 1, pos.s_row + 1, false, { "" })
     vim.api.nvim_win_set_cursor(0, { pos.s_row + 2, 0 })
 
+    current_line = {}
     return
   end
 
   -- append a new text after the cursor
-  vim.api.nvim_buf_set_text(bufnr, pos.s_row, pos.s_col, pos.e_row, pos.e_col, { word })
+  table.insert(current_line, word)
+  vim.api.nvim_buf_set_lines(bufnr, pos.s_row, pos.s_row + 1, false, { table.concat(current_line, "") })
 
   -- move the cursor to the end of the inserted text
   vim.api.nvim_win_set_cursor(0, { pos.s_row + 1, pos.s_col + word:len() })
@@ -71,6 +73,7 @@ end
 M.reset_index = function()
   index = 1
   total_newline = 1
+  current_line = {}
 end
 
 return M


### PR DESCRIPTION
When the user has something like `jk` mapped to `Esc` there is a delay in input, so `TextChangedI` autocmd fires with bad timing, leaving `j` in the hacker buffer. Closes #4.